### PR TITLE
Replace jansson with jq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC := cc
 SRC := src/main.c src/make.c
 OBJS := $(SRC:.c=.o)
-LDLIBS := `pkg-config --cflags --libs jansson`
+LDLIBS := -lbsd
 
 PREFIX ?= /usr/local
 CFLAGS += -DPREFIX=\"$(PREFIX)\"

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -5,8 +5,13 @@ pkgname=$(echo $PWD | sed 's/\///g')
 #     exit 1
 # fi
 
-# Read pkg-config packages into array
-mapfile -t pkg_list < <(jq -r 'select(.started.execution.executable? // "" | contains("pkg-config")) | .started.execution.arguments[1:][] | select(startswith("--") | not)' events.json)
+# Read pkg-config packages into array from packages.txt
+if [ ! -f packages.txt ]; then
+    echo "Error: packages.txt not found. Run bear-intercept.sh first."
+    exit 1
+fi
+
+mapfile -t pkg_list < packages.txt
 
 echo "Found packages: ${pkg_list[@]}"
 

--- a/scripts/apt-uninstall.sh
+++ b/scripts/apt-uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 dir=$(echo $PWD | sed 's/\///g')
 dir=${dir,,}
+rm events.json packages.txt
 sudo apt remove $dir
 sudo apt autoremove
-

--- a/scripts/bear-intercept.sh
+++ b/scripts/bear-intercept.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Script to run bear intercept and capture events to events.json
+# Usage: bear-intercept.sh <build_command> [args...]
+
+if [ $# -eq 0 ]; then
+    echo "Error: No build command provided"
+    echo "Usage: $0 <build_command> [args...]"
+    exit 1
+fi
+
+# Run bear intercept with the provided command
+# Bear outputs events in NDJSON format (newline-delimited JSON)
+# We capture this to events.json
+bear intercept --output events.json -- "$@"
+
+if [ $? -ne 0 ]; then
+    echo "Error: bear intercept failed"
+    exit 1
+fi
+
+echo "Events captured to events.json"

--- a/scripts/bear-intercept.sh
+++ b/scripts/bear-intercept.sh
@@ -20,3 +20,27 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Events captured to events.json"
+
+# Parse events.json to extract pkg-config packages
+# This extracts all pkg-config arguments that don't start with "--"
+echo "Parsing pkg-config dependencies..."
+
+# Extract packages and write to packages.txt (one per line)
+jq -r 'select(.started.execution.executable? // "" | contains("pkg-config")) | .started.execution.arguments[1:][] | select(startswith("--") | not)' events.json > packages.txt
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to parse events.json with jq"
+    exit 1
+fi
+
+# Count the number of packages found
+pkg_count=$(wc -l < packages.txt | tr -d ' ')
+
+if [ "$pkg_count" -eq 0 ]; then
+    echo "Warning: No pkg-config packages found in build events"
+else
+    echo "Found $pkg_count pkg-config package(s):"
+    cat packages.txt
+fi
+
+echo "Package list written to packages.txt"

--- a/scripts/xbps-install.sh
+++ b/scripts/xbps-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 XBPS_DIR=~/.local/share/virt-pack/xbps
 
@@ -24,8 +24,13 @@ mkdir -p "$PKG_DIR"
 
 echo "resolving libs, in case of multiple choose one"
 
-# Read pkg-config packages into array
-mapfile -t pkg_list < <(jq -r 'select(.started.execution.executable? // "" | contains("pkg-config")) | .started.execution.arguments[1:][] | select(startswith("--") | not)' events.json)
+# Read pkg-config packages into array from packages.txt
+if [ ! -f packages.txt ]; then
+    echo "Error: packages.txt not found. Run bear-intercept.sh first."
+    exit 1
+fi
+
+mapfile -t pkg_list < packages.txt
 
 echo "Found packages: ${pkg_list[@]}"
 

--- a/scripts/xbps-install.sh
+++ b/scripts/xbps-install.sh
@@ -24,10 +24,14 @@ mkdir -p "$PKG_DIR"
 
 echo "resolving libs, in case of multiple choose one"
 
-pkgs=$(xlocate $1.pc | fzf -1 | cut -d' ' -f1)
-shift
+# Read pkg-config packages into array
+mapfile -t pkg_list < <(jq -r 'select(.started.execution.executable? // "" | contains("pkg-config")) | .started.execution.arguments[1:][] | select(startswith("--") | not)' events.json)
 
-for arg in "$@"; do
+echo "Found packages: ${pkg_list[@]}"
+
+pkgs=$(xlocate "${pkg_list[0]}.pc" | fzf -1 | cut -d' ' -f1)
+
+for arg in "${pkg_list[@]:1}"; do
     pkgs="$pkgs $(xlocate $arg.pc | fzf -1 | cut -d' ' -f1)"
 done
 

--- a/scripts/xbps-uninstall.sh
+++ b/scripts/xbps-uninstall.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 dir=$(echo $PWD | sed 's/\//_/g')
+rm events.json packages.txt
 sudo xbps-remove -R $dir

--- a/src/make.c
+++ b/src/make.c
@@ -12,9 +12,12 @@ void bear_intercept(int argc, char *argv[])
 {
     printf("Intercepting using bear...\n");
 
-    char cmd[256] = SCRIPTDIR "/bear-intercept.sh ";
+    char cmd[1024] = SCRIPTDIR "/bear-intercept.sh ";
     for (int i = 0; i < argc; i++) {
         strlcat(cmd, argv[i], sizeof(cmd));
+        if (i < argc - 1) {
+            strlcat(cmd, " ", sizeof(cmd));
+        }
     }
 
     printf("Running: %s\n",cmd);

--- a/src/make.c
+++ b/src/make.c
@@ -3,108 +3,16 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <jansson.h>
 #include <stdbool.h>
 #include "commands.h"
 #define PATH_MAX 4096
 
-char *join_args(int argc, char *argv[]); 
-void parse_libs(char **libs) {
-    fprintf(stderr, "(*) parse_libs started\n");
-    FILE *events = fopen("events.json", "r");
-    char buffer[65536];
-    size_t line = 0;
-    json_error_t error;
-    json_t *lib_array = json_array();
-    int index = 1;
-
-    while (fgets(buffer, sizeof(buffer), events))
-    {
-        line++;
-
-        json_t *event = json_loads(buffer, 0, &error);
-        if (!event)
-        {
-            fprintf(stderr, "JSON parse error on line %zu: %s\n", line, error.text);
-            continue;
-        }
-
-        json_t *started = json_object_get(event, "started");
-        if (!started)
-        {
-            json_decref(event);
-            continue;
-        }
-
-        json_t *execution = json_object_get(started, "execution");
-        if (!execution)
-        {
-            json_decref(event);
-            continue;
-        }
-
-        json_t *exe = json_object_get(execution, "executable");
-        if (!exe || !json_is_string(exe))
-        {
-            json_decref(event);
-            continue;
-        }
-
-        const char *exe_str = json_string_value(exe);
-        if (!strstr(exe_str, "pkg-config"))
-        {
-            json_decref(event);
-            continue;
-        }
-
-        json_t *args = json_object_get(execution, "arguments");
-        if (!args || !json_is_array(args))
-        {
-            json_decref(event);
-            continue;
-        }
-
-        json_t *arg;
-        size_t i;
-        json_array_foreach(args, i, arg)
-        {
-
-            int cont = 0;
-            if (!json_is_string(arg))
-                continue;
-
-            const char *arg_str = json_string_value(arg);
-
-            // skip the first token (pkg-config) and any flags
-            if (i == 0 || strncmp(arg_str, "--", 2)==0)
-                continue;
-
-            for (int j = 1; j < index; j++) {
-                if (strcmp(libs[j], arg_str) == 0)
-                    cont = 1;
-            }
-
-            if (cont)
-                continue;
-
-            // append to lib_array
-            // split arg_str by spaces to handle multiple libs in one argument
-            // char *arg_copy = strdup(arg_str);
-            libs[index] = strdup(arg_str);
-            fprintf(stderr, "%s:%d:%s: lib: %s\n", __FILE__, __LINE__, __func__, libs[index]);
-            index++;
-        }
-
-        json_decref(event);
-    }
-    libs[index] = NULL;
-}
-
+char *join_args(int argc, char *argv[]);
 void bear_intercept(int argc, char *argv[])
 {
     printf("Intercepting using bear...\n");
 
-    char cmd[256] = "bear intercept -- ";
+    char cmd[256] = SCRIPTDIR "/bear-intercept.sh ";
     for (int i = 0; i < argc; i++) {
         strlcat(cmd, argv[i], sizeof(cmd));
     }
@@ -122,17 +30,10 @@ int handle_make(int argc, char *argv[], const char *pkgmgr)
 {
     bear_intercept(argc, argv);
     // parser_main();
-    char *libs[256];
-    libs[0] = "installer";
-    parse_libs(libs);
 
     char installer[1024];
-    snprintf(installer, 1024, SCRIPTDIR "/%s-install.sh", pkgmgr); 
-
-
-	if (execv(installer, libs)) {
-    	perror("execv");
-	}
+    snprintf(installer, 1024, SCRIPTDIR "/%s-install.sh", pkgmgr);
+	execl(installer, "installer", (char*)NULL);
 
     return 0;
 }


### PR DESCRIPTION
# Changes
- remove references to jansson and create a new script for bear intercept
- use `jq` in the installer scripts to parse the `events.json` & feed pkg names for installation


# Review
- tested the program by running the examples in `test-make` & `test-cmake`, its able to install dependecies

# Issue
- Closes #12 